### PR TITLE
repaired regex for maximum compatibility (repairs #12)

### DIFF
--- a/lib/linter-javac.coffee
+++ b/lib/linter-javac.coffee
@@ -15,7 +15,9 @@ class LinterJavac extends Linter
   linterName: 'javac'
 
   # A regex pattern used to extract information from the executable's output.
-  regex: 'java:(?<line>\\d+): ((?<error>error)|(?<warning>warning)): (?<message>.+)[\\n\\r]'
+  regex: 'java:(?<line>\\d+): ?((?<error>error)|(?<warning>warning))?:? (?<message>.+)[\\n\\r]'
+
+  observer: null
 
   constructor: (editor) ->
     super(editor)


### PR DESCRIPTION
By adding two more optional operators in [line 18 of linter-javac.coffee](https://github.com/skylineproject/linter-javac/blob/fixregex/lib/linter-javac.coffee#L18), this linter becomes compatible with more versions of javac (1.6 and later, based on my testing).

This PR resolves the issue in #12 based on my testing. In addition, it repairs an unrelated deprecation cop error regarding the use of ```atom.config.unobserve```.

As a student, I frequently need to use JDK 1.6 to match the standards against which my professors will grade my work. This same issue surfaces for people who maintain legacy software. This patch adds support for these situations without breaking support for JDK 7 and JDK 8.

Thanks again for all your work this far! If you have any questions or comments, please let me know in a comment on this PR.
