### PR TITLE
Load environment variable CLASSPATH

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -27,7 +27,8 @@ module.exports =
       wd = path.dirname filePath
       # Use the text editor's working directory as the classpath.
       #  TODO: Make the classpath user configurable.
-      args = ['-Xlint:all', '-cp', wd, filePath]
+      classpath = process.env.CLASSPATH
+      args = ['-Xlint:all', '-cp', wd + ":" + classpath, filePath]
       messages = []
       helpers.exec(@javaExecutablePath, args, {stream: 'stderr'})
         .then (val) => return @parse(val, textEditor)

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -28,7 +28,7 @@ module.exports =
       # Use the text editor's working directory as the classpath.
       #  TODO: Make the classpath user configurable.
       classpath = process.env.CLASSPATH
-      args = ['-Xlint:all', '-cp', wd + ":" + classpath, filePath]
+      args = ['-Xlint:all', '-cp', wd + path.delimiter + classpath, filePath]
       messages = []
       helpers.exec(@javaExecutablePath, args, {stream: 'stderr'})
         .then (val) => return @parse(val, textEditor)


### PR DESCRIPTION
After the latest update the environment variable `CLASSPATH` is not taken in account so there is no way to use additional class paths. As the man page of *javac* says:
> -cp path or -classpath path
>             Specify where to find user class files, and (optionally) annotation processors and  source  files.
>             This  class  path  **overrides** the user class path in the CLASSPATH environment variable.

We are **overriding** the class path with the argument `'-cp', wd` at [line 30](https://github.com/AtomLinter/linter-javac/blob/master/lib/init.coffee#L30). I have load the environment variable and added it to the argument.