### PR TITLE
Support classpath configuration via .classpath files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,26 @@ This package will lint your `.java` opened files in Atom through [javac](http://
 You can configure linter-javac by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
 
     'linter-javac':
-      'javaExecutablePath': null # java path. run 'which javac' to find the path
+      # The path to javac.   The default (javac) should work as long as you have it
+      # in your system PATH.
+      'javaExecutablePath': "javac"
+      # Extra classpath.  This will be appended to the classpath when executing javac.
+      'classpath': ''
+
+You can also configure the classpath on a per-project basis.  Simply create a file
+named `.linter-javac.cson` somewhere within your project (ideally at the root of
+the project).  The linter will search
+for this file by starting at the directory of the file being compiled and then
+searching all parent directories within the project.  If you have more than one
+of these configuration files, it will use the one that is "closest" to the file
+being compiled.  Within `.linter-javac.cson` you can configure the classpath.  
+For example:
+
+    classpath: ".:./lib/junit.jar"
+
+This linter will execute `javac` within the directory of the `.linter-javac.cson`
+file, so relative paths can be considered to be relative to that `.cson`
+file.
 
 ## Other available linters
 There are other linters available - take a look at the linters [mainpage](https://github.com/AtomLinter/Linter).
-
-## Donation
-[![Share the love!](https://chewbacco-stuff.s3.amazonaws.com/donate.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KXUYS4ARNHCN8)

--- a/README.md
+++ b/README.md
@@ -18,20 +18,22 @@ You can configure linter-javac by editing ~/.atom/config.cson (choose Open Your 
       # Extra classpath.  This will be appended to the classpath when executing javac.
       'classpath': ''
 
-You can also configure the classpath on a per-project basis.  Simply create a file
-named `.linter-javac.cson` somewhere within your project (ideally at the root of
+## Classpath
+
+It is strongly recommended that you configure your classpath via a `.classpath`
+file within your project (typically at the root).  Simply create a file
+named `.classpath` somewhere within your project (ideally at the root of
 the project).  The linter will search
 for this file by starting at the directory of the file being compiled and then
 searching all parent directories within the project.  If you have more than one
 of these configuration files, it will use the one that is "closest" to the file
-being compiled.  Within `.linter-javac.cson` you can configure the classpath.  
-For example:
+being compiled.  Within `.classpath` place only the classpath to be used for the
+project (nothing else).  For example:
 
-    classpath: ".:./lib/junit.jar"
+    .:./lib/junit.jar
 
-This linter will execute `javac` within the directory of the `.linter-javac.cson`
-file, so relative paths can be considered to be relative to that `.cson`
-file.
+This linter will execute `javac` within the directory of the `.classpath`
+file, so relative paths can be considered to be relative to that file.
 
 ## Other available linters
 There are other linters available - take a look at the linters [mainpage](https://github.com/AtomLinter/Linter).

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^3.1.1",
-    "season": "^1.0.2"
+    "atom-linter": "^3.1.1"
   },
   "providedServices": {
     "linter": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": ">=3.0.0"
+    "atom-linter": "^3.1.1",
+    "season": "^1.0.2"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
This PR allows for configuration of the classpath on a per-project basis via .cson files.  The user can place a `.linter-javac.cson` file within their project and the linter will use the classpath that is provided within the file.

Additionally, it will execute the `javac` command in the directory of the `.cson` file so it is possible to use paths that are relative to the `.cson` configuration file.

 - README.md updated with documentation
 - Requires `season` for CSON parsing

This makes it much more convenient to configure different classpaths for each project.