### PR TITLE
Only lint files in .classpath directory

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -46,6 +46,8 @@ module.exports =
         wd = cpConfig.cfgDir
         # Use configured classpath
         cp = cpConfig.cfgCp
+        # Use config file location to import correct files
+        files = @getFilesEndingWith(wd, ".java")
 
       # Add extra classpath if provided
       cp += path.delimiter + @classpath if @classpath


### PR DESCRIPTION
This fixes #39, building on the fix for #31.