### PR TITLE
Derive current project root from active file

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -89,7 +89,18 @@ module.exports =
     return messages
 
   getProjectRootDir: ->
-    return atom.project.rootDirectories[0].path
+    textEditor = atom.workspace.getActiveTextEditor()
+    if !textEditor || !textEditor.getPath()
+      # default to building the first one if no editor is active
+      if (0 == atom.project.getPaths().length)
+        return false;
+
+      return atom.project.getPaths()[0];
+
+    # otherwise, build the one in the root of the active editor
+    return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find (p) =>
+      realpath = fs.realpathSync(p);
+      return textEditor.getPath().substr(0, realpath.length) == realpath;
 
   getFilesEndingWith: (startPath, endsWith) ->
     foundFiles = []


### PR DESCRIPTION
Whatever file is currently active in the editor, use
the root project of that as a path when finding other files
and classpath and the like.  May be the root casue of Issue #36.

Fixes #42