### PR TITLE
Asynchronously walk paths

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -17,7 +17,7 @@ module.exports =
       default: ''
 
   activate: ->
-    require('atom-package-deps').install('linter-javac')
+    require('atom-package-deps').install()
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-javac.javaExecutablePath',
       (newValue) =>

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -58,7 +58,7 @@ module.exports =
 
       atom.project.repositoryForDirectory(new Directory(searchDir))
         .then (repo) =>
-          @getFilesEndingWith searchDir, '.java', repo.isPathIgnored.bind(repo)
+          @getFilesEndingWith searchDir, '.java', repo?.isPathIgnored.bind(repo)
         .then (files) =>
           # Arguments to javac
           args = ['-Xlint:all']
@@ -122,7 +122,7 @@ module.exports =
       .then (fileStats) =>
         mapped = fileStats.map (stats, i) =>
           filename = path.join startPath, folderFiles[i]
-          if ignoreFn(filename)
+          if ignoreFn?(filename)
             return undefined
           else if stats.isDirectory()
             return @getFilesEndingWith filename, endsWith, ignoreFn

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,4 +1,4 @@
-{Directory, BufferedProcess, CompositeDisposable} = require 'atom'
+{Directory, CompositeDisposable} = require 'atom'
 path = require 'path'
 helpers = require 'atom-linter'
 voucher = require 'voucher'
@@ -99,22 +99,24 @@ module.exports =
     if !textEditor || !textEditor.getPath()
       # default to building the first one if no editor is active
       if (0 == atom.project.getPaths().length)
-        return false;
+        return false
 
-      return atom.project.getPaths()[0];
+      return atom.project.getPaths()[0]
 
     # otherwise, build the one in the root of the active editor
-    return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find (p) =>
-      realpath = fs.realpathSync(p);
-      return textEditor.getPath().substr(0, realpath.length) == realpath;
+    return atom.project.getPaths()
+      .sort((a, b) -> (b.length - a.length))
+      .find (p) ->
+        realpath = fs.realpathSync(p)
+        return textEditor.getPath().substr(0, realpath.length) == realpath
 
   getFilesEndingWith: (startPath, endsWith, ignoreFn) ->
     foundFiles = []
     folderFiles = []
     voucher fs.readdir, startPath
-      .then (files) =>
+      .then (files) ->
         folderFiles = files
-        Promise.all files.map (f) =>
+        Promise.all files.map (f) ->
           filename = path.join startPath, f
           voucher fs.lstat, filename
       .then (fileStats) =>
@@ -124,10 +126,10 @@ module.exports =
             return undefined
           else if stats.isDirectory()
             return @getFilesEndingWith filename, endsWith, ignoreFn
-          else if filename.indexOf(endsWith, filename.length - (endsWith.length)) >= 0
+          else if filename.endsWith(endsWith)
             return [ filename ]
 
-        Promise.all(mapped.filter(Boolean));
+        Promise.all(mapped.filter(Boolean))
 
       .then (fileArrays) ->
         [].concat.apply([], fileArrays)
@@ -138,8 +140,9 @@ module.exports =
     # project base directory.
     while atom.project.contains(d) or (d in atom.project.getPaths())
       try
+        file = path.join d, cpConfigFileName
         result =
-          cfgCp: fs.readFileSync( path.join(d, cpConfigFileName), { encoding: 'utf-8' } )
+          cfgCp: fs.readFileSync(file, { encoding: 'utf-8' })
           cfgDir: d
         result.cfgCp = result.cfgCp.trim()
         return result

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,7 @@
-{BufferedProcess, CompositeDisposable} = require 'atom'
+{Directory, BufferedProcess, CompositeDisposable} = require 'atom'
 path = require 'path'
 helpers = require 'atom-linter'
+voucher = require 'voucher'
 fs = require 'fs'
 cpConfigFileName = '.classpath'
 
@@ -35,7 +36,7 @@ module.exports =
     lint: (textEditor) =>
       filePath = textEditor.getPath()
       wd = path.dirname filePath
-      files = @getFilesEndingWith(@getProjectRootDir(), ".java")
+      searchDir = @getProjectRootDir()
       # Classpath
       cp = null
 
@@ -47,7 +48,7 @@ module.exports =
         # Use configured classpath
         cp = cpConfig.cfgCp
         # Use config file location to import correct files
-        files = @getFilesEndingWith(wd, ".java")
+        searchDir = wd
 
       # Add extra classpath if provided
       cp += path.delimiter + @classpath if @classpath
@@ -55,14 +56,19 @@ module.exports =
       # Add environment variable if it exists
       cp += path.delimiter + process.env.CLASSPATH if process.env.CLASSPATH
 
-      # Arguments to javac
-      args = ['-Xlint:all']
-      args = args.concat(['-cp', cp]) if cp?
-      args.push.apply(args, files)
+      atom.project.repositoryForDirectory(new Directory(searchDir))
+        .then (repo) =>
+          @getFilesEndingWith searchDir, '.java', repo.isPathIgnored.bind(repo)
+        .then (files) =>
+          # Arguments to javac
+          args = ['-Xlint:all']
+          args = args.concat(['-cp', cp]) if cp?
+          args.push.apply(args, files)
 
-      # Execute javac
-      helpers.exec(@javaExecutablePath, args, {stream: 'stderr', cwd: wd})
-        .then (val) => return @parse(val, textEditor)
+          # Execute javac
+          helpers.exec(@javaExecutablePath, args, {stream: 'stderr', cwd: wd})
+            .then (val) =>
+              @parse(val, textEditor)
 
   parse: (javacOutput, textEditor) ->
     # Regex to match the error/warning line
@@ -102,23 +108,29 @@ module.exports =
       realpath = fs.realpathSync(p);
       return textEditor.getPath().substr(0, realpath.length) == realpath;
 
-  getFilesEndingWith: (startPath, endsWith) ->
+  getFilesEndingWith: (startPath, endsWith, ignoreFn) ->
     foundFiles = []
-    if !fs.existsSync(startPath)
-      return foundFiles
-    files = fs.readdirSync(startPath)
-    i = 0
-    while i < files.length
-      filename = path.join(startPath, files[i])
-      stat = fs.lstatSync(filename)
-      if stat.isDirectory()
-        foundFiles.push.apply(foundFiles, @getFilesEndingWith(filename, endsWith))
-      else if filename.indexOf(endsWith, filename.length - (endsWith.length)) >= 0
-        foundFiles.push.apply(foundFiles, [filename])
-        #Array::push.apply foundFiles, filename
-      i++
-    return foundFiles
+    folderFiles = []
+    voucher fs.readdir, startPath
+      .then (files) =>
+        folderFiles = files
+        Promise.all files.map (f) =>
+          filename = path.join startPath, f
+          voucher fs.lstat, filename
+      .then (fileStats) =>
+        mapped = fileStats.map (stats, i) =>
+          filename = path.join startPath, folderFiles[i]
+          if ignoreFn(filename)
+            return undefined
+          else if stats.isDirectory()
+            return @getFilesEndingWith filename, endsWith, ignoreFn
+          else if filename.indexOf(endsWith, filename.length - (endsWith.length)) >= 0
+            return [ filename ]
 
+        Promise.all(mapped.filter(Boolean));
+
+      .then (fileArrays) ->
+        [].concat.apply([], fileArrays)
 
   findClasspathConfig: (d) ->
     # Search for the .classpath file starting in the given directory

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-linter": "^3.4.0",
-    "atom-package-deps": "^2.0.1",
+    "atom-package-deps": "^3.0.5",
     "voucher": "^0.1.2"
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-linter": "^3.1.1",
-    "atom-package-deps": "^2.0.1"
+    "atom-linter": "^3.4.0",
+    "atom-package-deps": "^2.0.1",
+    "voucher": "^0.1.2"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
This makes the interaction feel much snappier since Atom
doesn't lock up while walking the tree.

Also ignores any files/folders which are ignored by the
Repository backing the project.