### PR TITLE
Fix #94 - Add support for symlinks in the file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This package will lint your opened `.java`-files on save, using [javac][javac-do
 
 ## Latest Changes
 
-- 1.9.0 - adds generic support for localized javac output, supports chinese (see [issue 36](iss36)).
-- 1.8.1 - fixed outdated module-dependency (see [issue 85][iss85]).
-- 1.8.0 - introduced config-setting `verboseLogging` for debugging purposes; improved startup-speed.
+- 1.9.2 - Fixes faulty handling of symbolic links in the files path (see [issue 94][iss94]).
+- 1.9.1 - Hotfixes a bug introduced by 1.9.0.
+- 1.9.0 - Adds generic support for localized javac output, supports chinese (see [issue 36][iss36]).
 
 ### Planned Milestones
 
-- 2.0.0 - complete rewrite of linter-javac (see [issue 76][iss76]).
+- 2.0.0 - Complete rewrite of linter-javac (see [issue 76][iss76]).
 
 
 ## Installation
@@ -73,8 +73,8 @@ Yes please! Give us feedback, file bugs or just help us coding - join us on http
 
 
 
+[iss94]: https://github.com/AtomLinter/linter-javac/issues/94
 [iss36]: https://github.com/AtomLinter/linter-javac/issues/36
-[iss85]: https://github.com/AtomLinter/linter-javac/issues/85
 [iss76]: https://github.com/AtomLinter/linter-javac/issues/76
 [javac-docs]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html
 [wiki]: https://github.com/AtomLinter/linter-javac/wiki

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -90,7 +90,7 @@ module.exports =
     lint: (textEditor) =>
       filePath = textEditor.getPath()
       wd = path.dirname filePath
-      searchDir = @getProjectRootDir()
+      searchDir = @getProjectRootDir() || path.dirname filePath
       # Classpath
       cp = ''
 
@@ -118,9 +118,16 @@ module.exports =
           searchDir,
           '" as search-directory.'
 
-      atom.project.repositoryForDirectory(new Directory(searchDir))
+      console.log 'test:' + searchDir + typeof(searchDir)
+
+      lstats = fs.lstatSync searchDir
+
+      atom.project.repositoryForDirectory(
+        new Directory(searchDir, true)
+      )
         .then (repo) =>
-          @getFilesEndingWith searchDir, '.java', repo?.isPathIgnored.bind(repo)
+          @getFilesEndingWith searchDir,
+            '.java', repo?.isPathIgnored.bind(repo)
         .then (files) =>
           # Arguments to javac
           args = ['-Xlint:all']
@@ -130,24 +137,24 @@ module.exports =
           if @additionalOptions.length > 0
             args = args.concat @additionalOptions
             if @verboseLogging
-              @_log 'adding ',
+              @_log 'adding',
                 @additionalOptions.length,
-                ' additional javac-options.'
+                'additional javac-options.'
 
           if @verboseLogging
-            @_log 'collected the following arguments: ', args.join(' ')
+            @_log 'collected the following arguments:', args.join(' ')
 
           # add javac argsfile if filename has been configured
           if @javacArgsFilename
             args.push('@' + @javacArgsFilename)
             if @verboseLogging
-              @_log 'adding ', @javacArgsFilename, ' as argsfile.'
+              @_log 'adding', @javacArgsFilename, 'as argsfile.'
 
           args.push.apply(args, files)
           if @verboseLogging
-            @_log 'adding ',
+            @_log 'adding',
               files.length,
-              ' files to the javac-arguments (from "',
+              'files to the javac-arguments (from "',
               files[0],
               '" to "',
               files[files.length - 1]
@@ -171,21 +178,21 @@ module.exports =
           if sliceIndex < (args.length - 1)
             # coffeelint: disable=max_line_length
             console.warn """
-linter-javac: The lint-command is presumed to break the limit of #{cliLimit} characters on the #{_os.platform()}-platform.
-Dropping #{args.length - sliceIndex} source files, as a result javac may not resolve all dependencies.
-"""
+  linter-javac: The lint-command is presumed to break the limit of #{cliLimit} characters on the #{_os.platform()}-platform.
+  Dropping #{args.length - sliceIndex} source files, as a result javac may not resolve all dependencies.
+  """
             # coffeelint: enable=max_line_length
             args = args.slice(0, sliceIndex) # cut args down
             args.push(filePath) # ensure actual file is part
 
 
           if @verboseLogging
-            @_log 'calling javac with ',
+            @_log 'calling javac with',
               args.length,
-              ' arguments by invoking "', @javaExecutablePath,
-              '". The approximated command length is ',
+              'arguments by invoking "', @javaExecutablePath,
+              '". The approximated command length is',
               args.join(' ').length,
-              ' characters long, the last argument is: ',
+              'characters long, the last argument is:',
               args[args.length - 1]
 
           # Execute javac
@@ -194,7 +201,6 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
               if @verboseLogging
                 @_log 'parsing:\n', val
               @parse(val, textEditor)
-
 
   parse: (javacOutput, textEditor) ->
     languageCode = @_detectLanguageCode javacOutput
@@ -224,7 +230,7 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
             messages[lastIndex].range[0][1] = column
             messages[lastIndex].range[1][1] = column + 1
       if @verboseLogging
-        @_log 'returning ', messages.length, ' linter-messages.'
+        @_log 'returning', messages.length, 'linter-messages.'
 
     return messages
 
@@ -232,7 +238,7 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
     textEditor = atom.workspace.getActiveTextEditor()
     if !textEditor || !textEditor.getPath()
       # default to building the first one if no editor is active
-      if (0 == atom.project.getPaths().length)
+      if not atom.project.getPaths().length
         return false
 
       return atom.project.getPaths()[0]
@@ -242,6 +248,7 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
       .sort((a, b) -> (b.length - a.length))
       .find (p) ->
         realpath = fs.realpathSync(p)
+        # TODO: The following fails if there's a symlink in the path
         return textEditor.getPath().substr(0, realpath.length) == realpath
 
   getFilesEndingWith: (startPath, endsWith, ignoreFn) ->
@@ -291,7 +298,7 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
     for language, pattern of @patterns
       if javacOutput.match(pattern.detector)
         if @verboseLogging
-          @_log 'detected the following language-code: ', language
+          @_log 'detected the following language-code:', language
         return language
 
     return false
@@ -299,4 +306,4 @@ Dropping #{args.length - sliceIndex} source files, as a result javac may not res
   _log: (msgs...) ->
     if (msgs.length > 0)
       javacPrefix = 'linter-javac: '
-      console.log javacPrefix, msgs.join('')
+      console.log javacPrefix + msgs.join(' ')

--- a/spec/base-spec.coffee
+++ b/spec/base-spec.coffee
@@ -1,68 +1,56 @@
 # This file contains all specs to ensure the base-functionality of
 # this plugin.
 
-_path = require 'path'
+path = require 'path'
 
-
-_helpers = require _path.join(__dirname, '_spec-helpers.coffee')
-
+_helpers = require path.join(__dirname, '_spec-helpers.coffee')
 
 describe 'linter-javac', ->
   beforeEach ->
-    #atom.workspace.destroyActivePaneItem
+    @linter = require path.join(__dirname, '..', 'lib', 'init.coffee')
+      .provideLinter()
     waitsForPromise ->
       atom.packages.activatePackage 'linter-javac'
       atom.packages.activatePackage 'language-java'
 
-
-
   describe 'when using a faulty java-source file', ->
     beforeEach ->
-      java_file = _path.join(__dirname, 'fixtures', 'BrokenWorld.java')
+      atom.config.set 'linter-javac.verboseLogging', yes
+
+      java_file = path.join(__dirname, 'fixtures', 'BrokenWorld.java')
       waitsForPromise =>
-        atom.workspace.open(java_file)
-        .then (newtextEditor) =>
-          @textEditor = newtextEditor
-          @linter = require(_path.join(__dirname, '..', 'lib', 'init.coffee'))
-            .provideLinter()
+        atom.workspace.open java_file
+          .then (newtextEditor) =>
+            @textEditor = newtextEditor
 
     it 'returns at least 8 messages in the linter-message-object', ->
-      waitsForPromise( =>
-        @linter.lint(@textEditor).then( (messages) ->
-          expect(messages.length).toBeGreaterThan(7)
-        )
-      )
-
-
+      waitsForPromise =>
+        @linter.lint(@textEditor).then (messages) ->
+          expect messages.length
+            .toBeGreaterThan 7
 
   describe 'when using a correct java-source file', ->
     beforeEach ->
-      java_file = _path.join(__dirname, 'fixtures', 'HelloWorld.java')
+      java_file = path.join(__dirname, 'fixtures', 'HelloWorld.java')
       waitsForPromise =>
-        atom.workspace.open(java_file)
-        .then (newtextEditor) =>
-          @textEditor = newtextEditor
-          @linter = require(_path.join(__dirname, '..', 'lib', 'init.coffee'))
-            .provideLinter()
+        atom.workspace.open java_file
+          .then (newtextEditor) =>
+            @textEditor = newtextEditor
 
     it 'returns an empty linter-message-object', ->
       result = {}
-      expect(JSON.stringify(@linter.lint(@textEditor)))
-        .toEqual(JSON.stringify(result))
-
-
+      expect JSON.stringify(@linter.lint(@textEditor))
+        .toEqual JSON.stringify(result)
 
   describe 'when using an empty java-source file', ->
     beforeEach ->
-      java_file = _path.join(__dirname, 'fixtures', 'EmptyWorld.java')
+      java_file = path.join(__dirname, 'fixtures', 'EmptyWorld.java')
       waitsForPromise =>
-        atom.workspace.open(java_file)
-        .then (newtextEditor) =>
-          @textEditor = newtextEditor
-          @linter = require(_path.join(__dirname, '..', 'lib', 'init.coffee'))
-            .provideLinter()
+        atom.workspace.open java_file
+          .then (newtextEditor) =>
+            @textEditor = newtextEditor
 
     it 'returns an empty linter-message-object', ->
       result = {}
-      expect(JSON.stringify(@linter.lint(@textEditor)))
-        .toEqual(JSON.stringify(result))
+      expect JSON.stringify(@linter.lint(@textEditor))
+        .toEqual JSON.stringify(result)

--- a/spec/iss36-spec.coffee
+++ b/spec/iss36-spec.coffee
@@ -1,5 +1,5 @@
-# This file contains all specs to ensure the base-functionality of
-# this plugin.
+# This file contains all dedicated to issue #94
+# see https://github.com/AtomLinter/linter-javac/issues/34
 
 _fs = require 'fs'
 _path = require 'path'

--- a/spec/iss94-spec.coffee
+++ b/spec/iss94-spec.coffee
@@ -1,0 +1,49 @@
+# This file contains all dedicated to issue #94
+# see: https://github.com/AtomLinter/linter-javac/issues/94
+
+path = require 'path'
+
+_helpers = require path.join(__dirname, '_spec-helpers.coffee')
+
+describe 'linter-javac', ->
+  beforeEach ->
+    atom.config.set 'linter-javac.verboseLogging', yes
+    waitsForPromise ->
+      atom.packages.activatePackage 'linter-javac'
+      atom.packages.activatePackage 'language-java'
+
+  describe 'when using a symlink-dir as project-base', ->
+    beforeEach ->
+      java_file = path.join(__dirname, 'sym-fixtures', 'Test.java')
+      @linter = require(path.join(__dirname, '..', 'lib', 'init.coffee'))
+        .provideLinter()
+      waitsForPromise =>
+        atom.workspace.open(java_file)
+        .then (newtextEditor) =>
+          @textEditor = newtextEditor
+
+    it 'shouldn not throw an exception if a file is saved', ->
+      @textEditor.setText 'public class Test {}'
+      linting = () =>
+        return @linter.lint(@textEditor)
+
+      expect(linting).not.toThrow()
+
+  describe 'when using a symlink as a higher directory of the project', ->
+    beforeEach ->
+      java_file = path.join(
+        __dirname, 'sym-fixtures', 'sub-directory', 'Test.java'
+      )
+      @linter = require(path.join(__dirname, '..', 'lib', 'init.coffee'))
+        .provideLinter()
+      waitsForPromise =>
+        atom.workspace.open(java_file)
+        .then (newtextEditor) =>
+          @textEditor = newtextEditor
+
+    it 'shouldn not throw an exception if a file is saved', ->
+      @textEditor.setText 'public class Test {}'
+      linting = () =>
+        return @linter.lint(@textEditor)
+
+      expect(linting).not.toThrow()

--- a/spec/sym-fixtures
+++ b/spec/sym-fixtures
@@ -1,0 +1,1 @@
+fixtures


### PR DESCRIPTION
- Add specs for issue #94
- Add test to verify working symlinks as higher directories
- Fix Directory-call, add fallback path for getProjectRootDir
- Fix links, updated Latest Changes
- Add subdirectory to fixtures
- Refactor base-specs
- Fix issue reference in iss36-spec

> getProjectDir's implementation is faulty since it does not proper
handle the appearance of symlinks (see :251).

The current code base is getting a pain in the 🃏 - i'll start refactoring as soon as possible.