### PR TITLE
use project root dir as working dir for javac

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -92,10 +92,6 @@ module.exports =
 
     lint: (textEditor) =>
       filePath = textEditor.getPath()
-      # ORIGINAL:
-      # wd = path.dirname filePath
-      # HACK:
-      # (using project root dir as working dir for javac)
       wd = @getProjectRootDir() || path.dirname filePath
       searchDir = @getProjectRootDir() || path.dirname filePath
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -92,7 +92,11 @@ module.exports =
 
     lint: (textEditor) =>
       filePath = textEditor.getPath()
-      wd = path.dirname filePath
+      # ORIGINAL:
+      # wd = path.dirname filePath
+      # HACK:
+      # (using project root dir as working dir for javac)
+      wd = @getProjectRootDir() || path.dirname filePath
       searchDir = @getProjectRootDir() || path.dirname filePath
 
       # Classpath


### PR DESCRIPTION
This fixed issues like #131 for me.
The problem was that the working directory of javac was initialized at the directory of the file to be linted, not at the project root dir. With this PR I'd like to propose a fix to this, as it is the only possibility I currently see to get a good Java linting experience in Atom.